### PR TITLE
Check for empty titles in search plugin

### DIFF
--- a/plugins/search/kunena/kunena.php
+++ b/plugins/search/kunena/kunena.php
@@ -135,7 +135,13 @@ function plgSearchKunena($text, $phrase = '', $ordering = '', $areas = null) {
 		$row = new StdClass();
 		$row->id = $message->id;
 		$row->href = $message->getUrl();
+		//Check if the title of the post is empty and make sure
+		//that there's not an unclickable link created
+		if ($message->subject == NULL) {
+		$row->title = "Message title is empty";
+		} else {
 		$row->title = JString::substr($message->subject, '0', $contentLimit);
+		}
 		$row->section = $message->getCategory()->name;
 		$row->created = $message->time;
 		if ($bbcode) {


### PR DESCRIPTION
There is a possibility that the title of a message is empty when the forum has been migrated from a third-party forum. If this happens, the search plugin will create unclickable links.