### PR TITLE
fix required email and guest notification in form.php

### DIFF
--- a/plugins/content/kunenadiscuss/tmpl/form.php
+++ b/plugins/content/kunenadiscuss/tmpl/form.php
@@ -23,6 +23,9 @@ $bootstrap    = $pluginParams->get('bootstrap');
 				<div class="<?php echo $bootstrap; ?>6">
 					<div class="panel panel-default">
 						<div class="panel-body">
+                                                        <?php if (!$this->user->exists()) : ?>
+								<div class="alert alert-info"><?php echo JText::_('COM_KUNENA_GEN_GUEST'); ?></div>
+							<?php endif; ?>
 							<form accept-charset="UTF-8" action="" method="POST" name="postform">
 								<div class="form-group">
 									<label for="name"><?php echo JText::_('PLG_KUNENADISCUSS_NAME') ?></label>
@@ -34,7 +37,7 @@ $bootstrap    = $pluginParams->get('bootstrap');
 								<?php if (!$this->user->exists() && $this->config->askemail) : ?>
 									<div class="form-group">
 										<label for="email"><?php echo JText::_('PLG_KUNENADISCUSS_EMAIL') ?></label>
-										<input class="form-control" type="text" name="email" value="<?php echo $this->email ?>" />
+										<input class="form-control" type="text" name="email" value="<?php echo $this->email ?>" required/>
 									</div>
 								<?php endif; ?>
 								<textarea class="form-control counted" name="message" placeholder="<?php echo JText::_('PLG_KUNENADISCUSS_MESSAGE') ?>" rows="5" style="margin-bottom:10px;width:100%"></textarea>


### PR DESCRIPTION
Hi, fix for required email not being required in for (displays blue in stead of red. Check for required is currently coded but is only checked when form is posted. With this change the field is checked BEFORE posting :)

Second fix is the addition of the warning when not logged in. This is implemented on the kunena component and WAS implemented in KunenaDiscuss 3.x. This reintroduces this feature :)

Hope this helps!
Keep up the good work, you are doing an awesome job!
