### PR TITLE
Fix: Creation of dynamic property PlgContentKunenaDiscuss::$ktemplate…

### DIFF
--- a/plugins/content/kunenadiscuss/kunenadiscuss.php
+++ b/plugins/content/kunenadiscuss/kunenadiscuss.php
@@ -91,6 +91,13 @@ class PlgContentKunenaDiscuss extends CMSPlugin
     public $allowed = false;
 
     /**
+     * @var KunenaFactory
+     * @since Kunena
+     * 
+     */
+    public $ktemplate = null;
+
+    /**
      * Constructor Function
      *
      * @param   object  $subject  The object to observe


### PR DESCRIPTION
… is deprecated

Deprecated: Creation of dynamic property PlgContentKunenaDiscuss::$ktemplate is deprecated in /...../plugins/content/kunenadiscuss/kunenadiscuss.php on line 226

PHP 8.2 deprecated message found while testing J5