### PR TITLE
Unwanted error Kunena discuss

### DIFF
--- a/plugins/content/kunenadiscuss/src/Helper/KunenaDiscussHelper.php
+++ b/plugins/content/kunenadiscuss/src/Helper/KunenaDiscussHelper.php
@@ -537,16 +537,16 @@ class KunenaDiscussHelper
 
         $now = Factory::getDate()->toUnix();
 
-        if ($topic->exists()) {
-            // If current user doesn't have authorisation to read existing topic, we are done
-            if ($id && !$topic->isAuthorised('read')) {
-                $this->debug("showPlugin: Topic said {$topic->getError()}");
+      if ($topic->exists()) {
+    // If current user doesn't have authorisation to read existing topic, we are done
+    if ($id && !$topic->isAuthorised('read')) {
+        $this->debug("showPlugin: Access denied to topic {$topic->id} (topic may be deleted or user lacks permission)");
 
-                return '';
-            }
+        return '';
+    }
 
-            $category = $topic->getCategory();
-        } else {
+    $category = $topic->getCategory();
+} else {
             $this->debug("showPlugin: Let's see what we can do..");
 
             // If current user doesn't have authorisation to read category, we are done


### PR DESCRIPTION
See https://www.kunena.org/forum/12-Community-Builder/168858-call-to-undefined-method-kunena-forum-libraries-user-kunenauser-get?start=10#233532
**The Problem:**

Plugin works fine when topic exists and is accessible
Plugin works fine when topic is permanently deleted (creates new topic)
Plugin fails only when topic is soft-deleted (hidden from non-moderators)

**Solution:**

✅ Fixed the immediate error with the debug message change
✅ Added suggestion to add the limitation to the manual/documentation

The fix prevents the fatal error
The issue only affects a very specific edge case (soft-deleted topics)
It's more of a workflow/documentation issue than a critical bug

For the manual/documentation, we could add something like:

**Note:** When moderators delete discussion topics, they should delete them permanently rather than just hiding them. Soft-deleted topics (visible only to moderators) will prevent the discussion plugin from working properly for regular users until the topic is either restored or permanently deleted.

BTW: I think link to download should be changed as well
![2025-06-12 Screenshot 1019](https://github.com/user-attachments/assets/81b9adb0-b294-4509-8a49-09ead21038b3)
